### PR TITLE
Add JSDoc comments to useLocalStorage

### DIFF
--- a/src/useLocalStorage.tsx
+++ b/src/useLocalStorage.tsx
@@ -7,8 +7,13 @@ if (typeof window === "undefined") {
   );
 }
 
-type UseLocalStorage<T> = [T, React.Dispatch<React.SetStateAction<T>>];
-
+/**
+ * A custom hook that synchronizes a state variable with localStorage.
+ * @template T
+ * @param {string} key - The key under which the value is stored in localStorage.
+ * @param {T} initialValue - The initial value to use if the key is not found in localStorage.
+ * @returns {UseLocalStorage<T>} A stateful value and a function to update it.
+ */
 function useLocalStorage<T>(key: string, initialValue: T): UseLocalStorage<T> {
   // Retrieve the initial value from localStorage or fall back to the default
   const [storedValue, setStoredValue] = useState<T>(() => {
@@ -21,7 +26,10 @@ function useLocalStorage<T>(key: string, initialValue: T): UseLocalStorage<T> {
     }
   });
 
-  // Update localStorage whenever the state changes
+  /**
+   * Update localStorage whenever the state changes.
+   * @param {React.SetStateAction<T>} value - The new value to store.
+   */
   const setValue: React.Dispatch<React.SetStateAction<T>> = useCallback(
     (value) => {
       try {
@@ -38,5 +46,14 @@ function useLocalStorage<T>(key: string, initialValue: T): UseLocalStorage<T> {
 
   return [storedValue, setValue];
 }
+
+/**
+ * A type representing the return value of the useLocalStorage hook.
+ * @template T
+ * @typedef {Array} UseLocalStorage
+ * @property {T} 0 - The current value.
+ * @property {React.Dispatch<React.SetStateAction<T>>} 1 - The function to update the value.
+ */
+type UseLocalStorage<T> = [T, React.Dispatch<React.SetStateAction<T>>];
 
 export default useLocalStorage;


### PR DESCRIPTION
Add inline JSDoc comments to `useLocalStorage` function and related types.

* **useLocalStorage function**
  - Add JSDoc comment describing the function, its parameters, and return value.

* **setValue function**
  - Add JSDoc comment describing the function and its parameter.

* **UseLocalStorage type**
  - Add JSDoc comment describing the type and its properties.

